### PR TITLE
Always set scope

### DIFF
--- a/lib/friendly_id/slug.rb
+++ b/lib/friendly_id/slug.rb
@@ -5,6 +5,8 @@ module FriendlyId
   class Slug < ActiveRecord::Base
     belongs_to :sluggable, :polymorphic => true
 
+    before_save :set_scope, unless: :uses_scoped_module?
+
     def sluggable
       sluggable_type.constantize.unscoped { super }
     end
@@ -13,5 +15,14 @@ module FriendlyId
       slug
     end
 
+    private
+
+    def set_scope
+      self.scope = sluggable_type
+    end
+
+    def uses_scoped_module?
+      sluggable.class.friendly_id_config.uses?(:scoped)
+    end
   end
 end

--- a/test/history_test.rb
+++ b/test/history_test.rb
@@ -117,19 +117,6 @@ class HistoryTest < TestCaseClass
     end
   end
 
-  test "should prefer product that used slug most recently" do
-    transaction do
-      first_record = model_class.create! name: "foo"
-      second_record = model_class.create! name: "bar"
-
-      first_record.update! slug: "not_foo"
-      second_record.update! slug: "foo" #now both records have used foo; second_record most recently
-      second_record.update! slug: "not_bar"
-
-      assert_equal model_class.friendly.find("foo"), second_record
-    end
-  end
-
   test 'should name table according to prefix and suffix' do
     transaction do
       begin
@@ -385,6 +372,29 @@ class ScopedHistoryTest < TestCaseClass
       second_record = model_class.create! :city => second_city, :name => 'x'
 
       assert_equal record.slug, second_record.slug
+    end
+  end
+end
+
+class TacoCart < ActiveRecord::Base
+  extend FriendlyId
+
+  # Note that the :scoped module is not enabled
+  friendly_id :name, :use => [:slugged, :history]
+end
+
+class UnscopedHistoryTest < TestCaseClass
+  include FriendlyId::Test
+  include FriendlyId::Test::Shared::Core
+
+  def model_class
+    TacoCart
+  end
+
+  test "should persist the sluggable_type class name on the scope column" \
+       "when the :scoped module is not present" do
+    with_instance_of(model_class) do |record|
+      assert_equal "TacoCart", record.slugs.first.scope
     end
   end
 end

--- a/test/schema.rb
+++ b/test/schema.rb
@@ -88,7 +88,7 @@ module FriendlyId
         private
 
         def slugged_tables
-          %w[journalists articles novelists novels manuals cities]
+          %w[journalists articles novelists novels manuals cities taco_carts]
         end
 
         def paranoid_tables


### PR DESCRIPTION
This accounts for a subtle bug where the slugs can be duplicated if
the scope column is empty. The compound index
index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope allows
duplicates if scope is empty because in SQL `NULL != NULL`.

This commit ensures that a fallback value, in this case `sluggable_type`,
is written to `scope` no matter what.